### PR TITLE
Update maven-bundle-plugin and hamcrest-all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
-            <version>1.1</version>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -130,7 +130,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-		<version>4.2.1</version>
+		        <version>5.1.2</version>
                 <extensions>true</extensions>
 
                 <executions>


### PR DESCRIPTION
The repository does not currently compile under Java 14 due to some outdated dependencies.
This updates a couple which then allows the library to compile and tests to pass.